### PR TITLE
Issue 9: Bump up Pravega and build versions in master for v0.7.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 
-pravegaVersion=0.6.1
+pravegaVersion=0.7.0
 keycloakVersion=6.0.1
 slf4jVersion=1.7.25
 junitVersion=4.12
@@ -21,4 +21,4 @@ publishRepo=
 bintrayOrgName=pravega
 bintrayRepoName=pravega
 
-buildVersion=0.7.0-SNAPSHOT
+buildVersion=0.8.0-SNAPSHOT


### PR DESCRIPTION
Update Pravega and build versions in gradle.properties to `0.7.0` and `0.8.0-SNAPSHOT`, respectively for master branch.

Resolves #9.