### PR TITLE
Fix issue 17 - retry http errors

### DIFF
--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthenticationException.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthenticationException.java
@@ -17,7 +17,7 @@ package io.pravega.keycloak.client;
  */
 public class KeycloakAuthenticationException extends RuntimeException {
 
-    public KeycloakAuthenticationException(Throwable e) {
-        super("Authentication failure", e);
+    public KeycloakAuthenticationException() {
+        super("Authentication failure");
     }
 }

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthenticationException.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthenticationException.java
@@ -16,8 +16,7 @@ package io.pravega.keycloak.client;
  * ( Strangely, things like providing a bad client secret result in a 400 error )
  */
 public class KeycloakAuthenticationException extends RuntimeException {
-
-    public KeycloakAuthenticationException() {
-        super("Authentication failure");
+    public KeycloakAuthenticationException(Throwable e) {
+        super("Authentication failure", e);
     }
 }

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthorizationException.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthorizationException.java
@@ -17,8 +17,7 @@ package io.pravega.keycloak.client;
  * result in a 400 error )
  */
 public class KeycloakAuthorizationException extends RuntimeException {
-
-    public KeycloakAuthorizationException() {
-        super();
+    public KeycloakAuthorizationException(Throwable e) {
+        super("Authorization failure", e);
     }
 }

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthorizationException.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthorizationException.java
@@ -17,7 +17,8 @@ package io.pravega.keycloak.client;
  * result in a 400 error )
  */
 public class KeycloakAuthorizationException extends RuntimeException {
-    public KeycloakAuthorizationException(Throwable e) {
-        super("Authorization failure", e);
+
+    public KeycloakAuthorizationException() {
+        super();
     }
 }

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
@@ -93,7 +93,7 @@ public class KeycloakAuthzClient {
                 throw new KeycloakAuthenticationException(e);
             }
 
-            // obtain an RPT
+            // obtain a Relying Party Token (RPT)
             AuthorizationRequest request = new AuthorizationRequest();
             try {
                 token = Retry.withExpBackoff(httpInitialDelayMs, 2, httpMaxRetries)

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
@@ -48,8 +48,8 @@ public class KeycloakAuthzClient {
 
     private final AuthzClient client;
     private final TokenCache tokenCache;
-    private int httpMaxRetries = DEFAULT_HTTP_MAX_RETRIES;
-    private int httpInitialDelayMs = DEFAULT_HTTP_INITIAL_DELAY_MS;
+    private final int httpMaxRetries;
+    private final int httpInitialDelayMs;
 
     /**
      * Builds a Keycloak authorization client.
@@ -61,10 +61,13 @@ public class KeycloakAuthzClient {
     public KeycloakAuthzClient(AuthzClient client, TokenCache tokenCache) {
         this.client = client;
         this.tokenCache = tokenCache;
+        this.httpMaxRetries = DEFAULT_HTTP_MAX_RETRIES;
+        this.httpInitialDelayMs = DEFAULT_HTTP_INITIAL_DELAY_MS;
     }
 
     public KeycloakAuthzClient(AuthzClient client, TokenCache tokenCache, int httpMaxRetries, int httpInitialDelayMs) {
-        this(client, tokenCache);
+        this.client = client;
+        this.tokenCache = tokenCache;
         this.httpMaxRetries = httpMaxRetries;
         this.httpInitialDelayMs = httpInitialDelayMs;
     }
@@ -74,7 +77,7 @@ public class KeycloakAuthzClient {
      *
      * @return a encoded RPT.
      */
-    public String getRPT() {\
+    public String getRPT() {
         AuthorizationResponse token;
         // check the token cache
         synchronized (tokenCache) {

--- a/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
+++ b/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
@@ -10,6 +10,7 @@
 
 package io.pravega.keycloak.client;
 
+import io.pravega.common.util.RetriesExhaustedException;
 import io.pravega.keycloak.client.KeycloakAuthzClient.TokenCache;
 import io.pravega.keycloak.client.helpers.AccessTokenBuilder;
 import io.pravega.keycloak.client.helpers.AccessTokenIssuer;
@@ -26,6 +27,7 @@ import org.keycloak.util.BasicAuthHelper;
 import org.mockito.Mockito;
 
 import java.io.File;
+import java.net.ConnectException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +44,7 @@ public class KeycloakAuthzClientTest {
     private static final AccessTokenIssuer ISSUER = new AccessTokenIssuer();
 
     @Test
-    public void getRPT_caching() {
+    public void getRPTCacheHits() {
         AuthzClient client = mock(AuthzClient.class, Mockito.RETURNS_DEEP_STUBS);
         TokenCache tokenCache = spy(new TokenCache(0));
 
@@ -67,7 +69,7 @@ public class KeycloakAuthzClientTest {
     }
 
     @Test
-    public void getRPT_error_authn() {
+    public void getRPTFailsToGetAccessToken() {
         AuthzClient client = mock(AuthzClient.class, Mockito.RETURNS_DEEP_STUBS);
         TokenCache tokenCache = spy(new TokenCache(0));
         when(client.obtainAccessToken()).thenThrow(new HttpResponseException("", 400, "", null));
@@ -76,14 +78,13 @@ public class KeycloakAuthzClientTest {
         try {
             authzClient.getRPT();
             Assert.fail();
-        }
-        catch(KeycloakAuthenticationException e) {
+        } catch(KeycloakAuthenticationException e) {
         }
         verify(client, times(1)).obtainAccessToken();
     }
 
     @Test
-    public void getRPT_error_authz() {
+    public void getRPTCannotExchangeAccessTokenForRPT() {
         AuthzClient client = mock(AuthzClient.class, Mockito.RETURNS_DEEP_STUBS);
         TokenCache tokenCache = spy(new TokenCache(0));
         AccessTokenResponse accessToken = accessTokenResponse();
@@ -94,33 +95,66 @@ public class KeycloakAuthzClientTest {
         try {
             authzClient.getRPT();
             Assert.fail();
+        } catch(KeycloakAuthorizationException e) {
         }
-        catch(KeycloakAuthorizationException e) {
-        }
-        verify(client, times(1)).obtainAccessToken();
+        verify(client.authorization(any()), times(1)).authorize(any());
     }
 
     @Test
-    public void getRPT_error_other() {
+    public void getRPTWithHttp500Exception() {
         AuthzClient client = mock(AuthzClient.class, Mockito.RETURNS_DEEP_STUBS);
         TokenCache tokenCache = spy(new TokenCache(0));
-        when(client.obtainAccessToken()).thenThrow(new HttpResponseException("", 500, "", null));
 
+        when(client.obtainAccessToken()).thenThrow(new HttpResponseException("", 500, "", null));
         KeycloakAuthzClient authzClient = new KeycloakAuthzClient(client, tokenCache);
         authzClient.setHttpMaxRetries(3);
-        authzClient.setHttpRetriesDelayMsecs(1);
+        authzClient.setHttpInitialDelayMs(1);
         try {
             authzClient.getRPT();
             Assert.fail();
-        }
-        catch(HttpResponseException e) {
-            int i = 0;
+        } catch(RetriesExhaustedException e) {
         }
         verify(client, times(3)).obtainAccessToken();
     }
 
     @Test
-    public void tokenCache_expiration() {
+    public void getRPTWithRuntimeConnectException() {
+        AuthzClient client = mock(AuthzClient.class, Mockito.RETURNS_DEEP_STUBS);
+        TokenCache tokenCache = spy(new TokenCache(0));
+
+        when(client.obtainAccessToken()).thenThrow(new RuntimeException(new ConnectException()));
+        KeycloakAuthzClient authzClient = new KeycloakAuthzClient(client, tokenCache);
+        authzClient.setHttpMaxRetries(3);
+        authzClient.setHttpInitialDelayMs(1);
+        try {
+            authzClient.getRPT();
+            Assert.fail();
+        } catch(RetriesExhaustedException e) {
+        }
+        verify(client, times(3)).obtainAccessToken();
+    }
+
+    @Test
+    public void getRPTWithRandomRuntimeException() {
+        AuthzClient client = mock(AuthzClient.class, Mockito.RETURNS_DEEP_STUBS);
+        TokenCache tokenCache = spy(new TokenCache(0));
+
+        when(client.obtainAccessToken()).thenThrow(new RuntimeException("bogus"));
+        KeycloakAuthzClient authzClient = new KeycloakAuthzClient(client, tokenCache);
+        authzClient.setHttpMaxRetries(3);
+        authzClient.setHttpInitialDelayMs(1);
+        try {
+            authzClient.getRPT();
+            Assert.fail();
+        } catch(RetriesExhaustedException e) {
+            Assert.fail();
+        } catch (RuntimeException e) {
+        }
+        verify(client, times(1)).obtainAccessToken();
+    }
+
+    @Test
+    public void tokenCacheExpiration() {
         AuthorizationResponse response;
         TokenCache tokenCache = new TokenCache(0);
 
@@ -140,14 +174,14 @@ public class KeycloakAuthzClientTest {
     }
 
     @Test
-    public void builder_defaultAudience() {
+    public void builderDefaultAudience() {
         TestSupplier supplier = new TestSupplier();
         KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).withConfigFile(SVC_ACCOUNT_JSON_FILE).build();
         assertEquals(DEFAULT_PRAVEGA_CONTROLLER_CLIENT_ID, supplier.configuration.getResource());
     }
 
     @Test
-    public void builder_setAudience() {
+    public void builderSetAudience() {
         TestSupplier supplier = new TestSupplier();
         KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).withConfigFile(SVC_ACCOUNT_JSON_FILE)
                 .withAudience("builder_setAudience").build();
@@ -155,13 +189,13 @@ public class KeycloakAuthzClientTest {
     }
 
     @Test(expected = KeycloakConfigurationException.class)
-    public void builder_noConfig() {
+    public void builderNoConfig() {
         TestSupplier supplier = new TestSupplier();
         KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).build();
     }
 
     @Test
-    public void builder_authenticator() {
+    public void builderAuthenticator() {
         TestSupplier supplier = new TestSupplier();
         KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).withConfigFile(SVC_ACCOUNT_JSON_FILE).build();
 

--- a/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
+++ b/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
@@ -106,9 +106,7 @@ public class KeycloakAuthzClientTest {
         TokenCache tokenCache = spy(new TokenCache(0));
 
         when(client.obtainAccessToken()).thenThrow(new HttpResponseException("", 500, "", null));
-        KeycloakAuthzClient authzClient = new KeycloakAuthzClient(client, tokenCache);
-        authzClient.setHttpMaxRetries(3);
-        authzClient.setHttpInitialDelayMs(1);
+        KeycloakAuthzClient authzClient = new KeycloakAuthzClient(client, tokenCache, 3, 1);
         try {
             authzClient.getRPT();
             Assert.fail();
@@ -123,9 +121,7 @@ public class KeycloakAuthzClientTest {
         TokenCache tokenCache = spy(new TokenCache(0));
 
         when(client.obtainAccessToken()).thenThrow(new RuntimeException(new ConnectException()));
-        KeycloakAuthzClient authzClient = new KeycloakAuthzClient(client, tokenCache);
-        authzClient.setHttpMaxRetries(3);
-        authzClient.setHttpInitialDelayMs(1);
+        KeycloakAuthzClient authzClient = new KeycloakAuthzClient(client, tokenCache,3, 1);
         try {
             authzClient.getRPT();
             Assert.fail();
@@ -140,9 +136,7 @@ public class KeycloakAuthzClientTest {
         TokenCache tokenCache = spy(new TokenCache(0));
 
         when(client.obtainAccessToken()).thenThrow(new RuntimeException("bogus"));
-        KeycloakAuthzClient authzClient = new KeycloakAuthzClient(client, tokenCache);
-        authzClient.setHttpMaxRetries(3);
-        authzClient.setHttpInitialDelayMs(1);
+        KeycloakAuthzClient authzClient = new KeycloakAuthzClient(client, tokenCache, 3, 1);
         try {
             authzClient.getRPT();
             Assert.fail();


### PR DESCRIPTION
**Changelog description:** 

This increases the robustness of the Keycloak interactions by retrying all errors resulting in HttpResponseException, except for BadRequest, Forbidden or Unauthorized which by nature should not be retried.

**Purpose of the change:** 

Fixes https://github.com/pravega/pravega-keycloak/issues/17

**What the code does:** 

The main change in this PR is adding retries around the 2 main calls that the Keycloak Authz Client does which is to obtain an access token, or the exchange of the access to token for an RPT.

HttpResponseException with error code of 400, 401, 403 are not retried as they are authentication errors. (400 is bad request but is sometimes returned with a bad client secret).    All other httpresponsesexceptions are retried.  Typically, 500, 502, 503s would be what happen with temporary connectivity issues.

The defaults are to retry 10 times with 5 seconds in between.

Random exceptions are not retried.    

**How to verify it:** 

Unit tests have been updated to reflect the new changes.

Beyond that, integration testing was done using a custom program that uses this library.   The following faults were injected and appropriate reaction from the KeycloakAuthzClient observed.

Loss of connectivity to Keycloak, then repaired connectivity:

```
7T13:34:20.652221051Z 	at com.google.auth.Credentials.blockingGetToCallback(Credentials.java:103)
2020-08-07T13:34:20.652222951Z 	at com.google.auth.Credentials$1.run(Credentials.java:92)
2020-08-07T13:34:20.652224951Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2020-08-07T13:34:20.652226951Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2020-08-07T13:34:20.652228851Z 	at java.lang.Thread.run(Thread.java:748)
2020-08-07T13:34:20.814505152Z 13:34:20.814 [grpc-default-executor-1] DEBUG io.pravega.common.util.Retry - Retrying command io.pravega.keycloak.client.KeycloakAuthzClient$$Lambda$54/938889730@63a564f2 Retry #2, timestamp=2020-08-07T13:34:20.814Z
2020-08-07T13:34:20.815546072Z 13:34:20.815 [grpc-default-executor-1] WARN io.pravega.keycloak.client.KeycloakAuthzClient - Retryable connection exception: Connection refused (Connection refused)
2020-08-07T13:34:20.815557072Z java.net.ConnectException: Connection refused (Connection refused)
2020-08-07T13:34:20.815559772Z 	at java.net.PlainSocketImpl.socketConnect(Native Method)
2020-08-07T13:34:20.815561872Z 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
2020-08-07T13:34:20.815563772Z 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
2020-08-07T13:34:20.815565672Z 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
...
07T13:34:26.82189184Z 	at com.google.auth.Credentials$1.run(Credentials.java:92)
2020-08-07T13:34:26.82189374Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2020-08-07T13:34:26.82189574Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2020-08-07T13:34:26.82189764Z 	at java.lang.Thread.run(Thread.java:748)
2020-08-07T13:34:33.05924767Z 13:34:33.058 [grpc-default-executor-2] DEBUG io.pravega.common.util.Retry - Retrying command io.pravega.keycloak.client.KeycloakAuthzClient$$Lambda$54/938889730@6e6a7d3c Retry #7, timestamp=2020-08-07T13:34:33.058Z
2020-08-07T13:34:33.085722775Z 13:34:33.085 [grpc-default-executor-2] INFO io.pravega.keycloak.client.KeycloakAuthzClient - Obtained access token from Keycloak
```

Invalidated credentials in Keycloak to induce an authentication error and making sure it doesn't get retried:

```
2020-08-07T13:47:26.054885036Z 13:47:26.054 [grpc-default-executor-1] ERROR io.pravega.keycloak.client.KeycloakAuthzClient - Non retryable HttpResponseException: 401
2020-08-07T13:47:26.054901936Z 13:47:26.054 [grpc-default-executor-1] ERROR io.pravega.keycloak.client.KeycloakAuthzClient - Failed to obtain access token from Keycloak
2020-08-07T13:47:26.060084537Z 13:47:26.059 [grpc-default-executor-2] WARN io.pravega.client.control.impl.ControllerImpl - gRPC call for createStream with trace id -456302318789728547 and parameters [hello-scope, stream1, StreamConfiguration(scalingPolicy=ScalingPolicy(scaleType=FIXED_NUM_SEGMENTS, targetRate=0, scaleFactor=0, minNumSegments=1), retentionPolicy=null, timestampAggregationTimeout=0)] failed with server error.
2020-08-07T13:47:26.060111037Z io.grpc.StatusRuntimeException: UNAUTHENTICATED: Failed computing credential metadata
2020-08-07T13:47:26.060113737Z 	at io.grpc.Status.asRuntimeException(Status.java:530)
2020-08-07T13:47:26.060115737Z 	at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:434)
2020-08-07T13:47:26.060117637Z 	at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
```
