### PR TITLE
support direct injection of the keycloak JSON in the client configuration

### DIFF
--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
@@ -151,6 +151,7 @@ public class KeycloakAuthzClient {
     public static class Builder {
         private String audience;
         private String configFile;
+        private String configString = null;
         private BiFunction<Configuration, ClientAuthenticator, AuthzClient> clientSupplier;
 
         public Builder() {
@@ -164,6 +165,15 @@ public class KeycloakAuthzClient {
          */
         public Builder withConfigFile(String path) {
             this.configFile = path;
+            return this;
+        }
+
+        /**
+         * Sets the Keycloak client configuration String to use.
+         * @param configString Keycloak OIDC JSON as a String.
+         */
+        public Builder withConfigString(final String configString) {
+            this.configString = configString;
             return this;
         }
 
@@ -190,13 +200,18 @@ public class KeycloakAuthzClient {
         public KeycloakAuthzClient build() {
             Configuration configuration;
             try {
-                configuration = KeycloakConfigResolver.resolve(configFile).orElseThrow(() -> new KeycloakConfigurationException(
-                        "Unable to resolve a Keycloak client configuration for Pravega authentication purposes.\n\n" +
-                                "Use one of the following approaches to provide a client configuration (in Keycloak OIDC JSON format):\n" +
-                                "1. Use a builder method to set the path to a file.\n" +
-                                "2. Set the environment variable 'KEYCLOAK_SERVICE_ACCOUNT_FILE' to the path to a file.\n" +
-                                "3. Update the classpath to contain a resource named 'keycloak.json'.\n" +
-                                ""));
+                String errorMessage = "Unable to resolve a Keycloak client configuration for Pravega authentication purposes.\n\n" +
+                        "Use one of the following approaches to provide a client configuration (in Keycloak OIDC JSON format):\n" +
+                        "1. Use a builder method to set the keycloak OIDC config as a JSON string.\n" +
+                        "2. Use a builder method to set the path to a file.\n" +
+                        "3. Set the environment variable 'KEYCLOAK_SERVICE_ACCOUNT_FILE' to the path to a file.\n" +
+                        "4. Update the classpath to contain a resource named 'keycloak.json'.\n" +
+                        "";
+                if (configString != null) {
+                    configuration = KeycloakConfigResolver.resolveFromString(configString).orElseThrow(() -> new KeycloakConfigurationException(errorMessage));
+                } else {
+                    configuration = KeycloakConfigResolver.resolve(configFile).orElseThrow(() -> new KeycloakConfigurationException(errorMessage));
+                }
             } catch (IOException e) {
                 throw new KeycloakConfigurationException("Unexpected error in resolving or loading the Keycloak client configuration", e);
             }

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
@@ -208,7 +208,7 @@ public class KeycloakAuthzClient {
     public static class Builder {
         private String audience;
         private String configFile;
-        private String configString = null;
+        private String configString;
         private BiFunction<Configuration, ClientAuthenticator, AuthzClient> clientSupplier;
         private int httpMaxRetries;
         private int httpInitialDelayMs;

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakConfigResolver.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakConfigResolver.java
@@ -104,6 +104,7 @@ public class KeycloakConfigResolver {
 
     static Optional<InputStream> string(String configString) {
         if (configString != null && configString.trim().length() > 0) {
+            LOG.debug("Loaded configuration from string");
             return Optional.of(new ByteArrayInputStream(configString.getBytes(StandardCharsets.UTF_8)));
         }
         return Optional.empty();

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakConfigResolver.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakConfigResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.keycloak.client;
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 /**
  * A resolver for Keycloak {@link Configuration} objects.
- * <p>
+ *
  * The following methods are attempted, in order, to load a Keycloak adapter configuration:
  * 1. an explicit file location pointing to a Keycloak adapter configuration file
  * 2. an environment variable pointing to the location of an adapter configuration file

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakConfigResolver.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakConfigResolver.java
@@ -10,6 +10,7 @@
 
 package io.pravega.keycloak.client;
 
+import com.google.common.base.Strings;
 import org.keycloak.authorization.client.Configuration;
 import org.keycloak.util.JsonSerialization;
 import org.slf4j.Logger;
@@ -103,7 +104,7 @@ public class KeycloakConfigResolver {
     }
 
     static Optional<InputStream> string(String configString) {
-        if (configString != null && configString.trim().length() > 0) {
+        if (!Strings.isNullOrEmpty(configString)) {
             LOG.debug("Loaded configuration from string");
             return Optional.of(new ByteArrayInputStream(configString.getBytes(StandardCharsets.UTF_8)));
         }

--- a/client/src/main/java/io/pravega/keycloak/client/PravegaKeycloakCredentials.java
+++ b/client/src/main/java/io/pravega/keycloak/client/PravegaKeycloakCredentials.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.keycloak.client;
@@ -13,6 +13,12 @@ package io.pravega.keycloak.client;
 import io.pravega.client.stream.impl.Credentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 
 import static io.pravega.auth.AuthConstants.BEARER;
 
@@ -26,8 +32,15 @@ public class PravegaKeycloakCredentials implements Credentials {
 
     // The actual keycloak client won't be serialized.
     private transient KeycloakAuthzClient kc = null;
+    private String keycloakJsonString = null;
 
     public PravegaKeycloakCredentials() {
+        init();
+        LOG.info("Loaded Keycloak Credentials");
+    }
+
+    public PravegaKeycloakCredentials(String keycloakJsonString) {
+        this.keycloakJsonString = keycloakJsonString;
         init();
         LOG.info("Loaded Keycloak Credentials");
     }
@@ -45,7 +58,27 @@ public class PravegaKeycloakCredentials implements Credentials {
 
     private void init() {
         if (kc == null) {
-            kc = KeycloakAuthzClient.builder().build();
+            if (keycloakJsonString != null) {
+                try {
+                    // KeycloakAuthzClient requires a file. We write the authentication credentials to
+                    // a secure file and delete it immediately after initialization.
+                    final Path tempPath = Files.createTempFile("keycloak-", ".json",
+                            // Only user has permissions to the file.
+                            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+                    try {
+                        try (PrintWriter out = new PrintWriter(tempPath.toFile())) {
+                            out.println(keycloakJsonString);
+                        }
+                        kc = KeycloakAuthzClient.builder().withConfigFile(tempPath.toString()).build();
+                    } finally {
+                        Files.delete(tempPath);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                kc = KeycloakAuthzClient.builder().build();
+            }
         }
     }
 }

--- a/client/src/main/java/io/pravega/keycloak/client/PravegaKeycloakCredentials.java
+++ b/client/src/main/java/io/pravega/keycloak/client/PravegaKeycloakCredentials.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.keycloak.client;

--- a/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
+++ b/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
@@ -210,11 +210,11 @@ public class KeycloakAuthzClientTest {
     @Test
     void builderAuthenticator(boolean isFile) {
         TestSupplier supplier = new TestSupplier();
-        if (isFile)
+        if (isFile) {
             KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).withConfigFile(SVC_ACCOUNT_JSON_FILE).build();
-        else
+        } else {
             KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).withConfigString(SVC_ACCOUNT_JSON_STRING).build();
-
+        }
         Map<String, List<String>> requestParams = new HashMap<>();
         Map<String, String> requestHeaders = new HashMap<>();
         supplier.clientAuthenticator.configureClientCredentials(requestParams, requestHeaders);

--- a/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
+++ b/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
@@ -207,7 +207,6 @@ public class KeycloakAuthzClientTest {
         KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).build();
     }
 
-    @Test
     void builderAuthenticator(boolean isFile) {
         TestSupplier supplier = new TestSupplier();
         if (isFile) {

--- a/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
+++ b/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
@@ -159,10 +159,12 @@ public class KeycloakAuthzClientTest {
         KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).build();
     }
 
-    @Test
-    public void builder_authenticator() {
+    void builder_authenticator(boolean isFile) {
         TestSupplier supplier = new TestSupplier();
-        KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).withConfigFile(SVC_ACCOUNT_JSON_FILE).build();
+        if (isFile)
+            KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).withConfigFile(SVC_ACCOUNT_JSON_FILE).build();
+        else
+            KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).withConfigString(SVC_ACCOUNT_JSON_STRING).build();
 
         Map<String, List<String>> requestParams = new HashMap<>();
         Map<String, String> requestHeaders = new HashMap<>();
@@ -174,17 +176,13 @@ public class KeycloakAuthzClientTest {
     }
 
     @Test
-    public void builder_authenticatorFromString() {
-        TestSupplier supplier = new TestSupplier();
-        KeycloakAuthzClient.builder().withAuthzClientSupplier(supplier).withConfigString(SVC_ACCOUNT_JSON_STRING).build();
+    public void builder_authenticatorFromFile() {
+        builder_authenticator(true);
+    }
 
-        Map<String, List<String>> requestParams = new HashMap<>();
-        Map<String, String> requestHeaders = new HashMap<>();
-        supplier.clientAuthenticator.configureClientCredentials(requestParams, requestHeaders);
-        assertTrue(requestHeaders.containsKey("Authorization"));
-        assertEquals(
-                requestHeaders.get("Authorization"),
-                BasicAuthHelper.createHeader("test-client", "b3f202cb-29fe-4d13-afb8-15e787c6e56c"));
+    @Test
+    public void builder_authenticatorFromString() {
+        builder_authenticator(false);
     }
 
     @Test
@@ -233,9 +231,8 @@ public class KeycloakAuthzClientTest {
         try {
             return new String(Files.readAllBytes(Paths.get(resourceFilePath)));
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException("Could not load resource path: " + resourceFilePath, e);
         }
-        return null;
     }
 
     class TestSupplier implements BiFunction<Configuration, ClientAuthenticator, AuthzClient> {

--- a/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
+++ b/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  */
 
 package io.pravega.keycloak.client;


### PR DESCRIPTION
There is no way to pass the keycloak JSON file content as a string in the client configuration.

Fixes #19 
Add a constructor to get the keycloak JSON file content as a string. Then create a temporary file (Only user has permissions to the file) and bulid the `KeycloakAuthzClient `with this temporary file. After build the `KeycloakAuthzClient`, deleted the temporary file.