### PR TITLE
Issue 33: Update pravega dependency to 0.9.0 and set buildversion to …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,10 +14,10 @@ guavaVersion=28.2-jre
 junitVersion=4.13
 keycloakVersion=10.0.2
 mockitoVersion=3.3.3
-pravegaVersion=0.9.0-2718.6470c10-SNAPSHOT
+pravegaVersion=0.9.0
 slf4jVersion=1.7.30
 
-buildVersion=0.9.0-SNAPSHOT
+buildVersion=0.10.0-SNAPSHOT
 
 
 # The below release/publishing properties specified in this file below may be overridden by supplying project


### PR DESCRIPTION
Signed-off-by: Christophe Balczunas <christophe.balczunas@emc.com>

**Change log description**
Chang build version in master to 0.10.0-SNAPSHOT, and use the latest Pravega version (0.9.0 as dependency)

**Purpose of the change**
Resolves #33 .

**What the code does**
No code changes.  gradle.properties file update.

**How to verify it**
Look at the file gradle.properties file.

Tests should pass.