### PR TITLE
Issue 47: make retryable exception predicate less strict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocatio
 
 buildscript {
     repositories {
-        jcenter()
         mavenCentral()
     }
 }
@@ -33,9 +32,13 @@ subprojects {
     apply plugin: 'com.github.johnrengelman.shadow'
 
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
-            url "https://oss.jfrog.org/jfrog-dependencies"
+            url "https://maven.pkg.github.com/pravega/pravega"
+            credentials {
+                username = "pravega-public"
+                password = "\u0067\u0068\u0070\u005F\u0048\u0034\u0046\u0079\u0047\u005A\u0031\u006B\u0056\u0030\u0051\u0070\u006B\u0079\u0058\u006D\u0035\u0063\u0034\u0055\u0033\u006E\u0032\u0065\u0078\u0039\u0032\u0046\u006E\u0071\u0033\u0053\u0046\u0076\u005A\u0049"
+            }
         }
     }
 

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
@@ -118,10 +118,11 @@ public class KeycloakAuthzClient {
     }
 
     /**
-     * Predicate to determine what is retryable and what is not.
+     * Predicate to determine what exception is retryable and what is not.
+     * Typically, the incoming exception will be wrapped in a RuntimeException.
+     * It is unwrapped here to look at the root cause.
      * HttpResponseException with error code of 400, 401, 403 are not retryable.
-     * All other HttpResponseException are retryable as well as java.net.ConnectException.
-     * All others are not retryable.
+     * All other HttpResponseException are retryable as well as any other non HttpResponseException exceptions.
      * @return
      */
     private static Predicate<Throwable> isRetryable() {
@@ -140,8 +141,8 @@ public class KeycloakAuthzClient {
                     return true;
                 }
             }
-            LOG.warn("Retryable exception: ", e);
-            LOG.warn("Retryable exception root cause: ", rootCause);
+            LOG.warn("Retryable exception ", e);
+            LOG.warn("Retryable exception root cause", rootCause);
             return true;
         };
     }

--- a/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
+++ b/client/src/main/java/io/pravega/keycloak/client/KeycloakAuthzClient.java
@@ -128,7 +128,7 @@ public class KeycloakAuthzClient {
         return e -> {
             Throwable rootCause = unwrap(e);
             if (rootCause instanceof HttpResponseException) {
-                int statusCode = ((HttpResponseException) e).getStatusCode();
+                int statusCode = ((HttpResponseException) rootCause).getStatusCode();
                 if (statusCode == HttpStatus.SC_BAD_REQUEST ||
                         statusCode == HttpStatus.SC_UNAUTHORIZED ||
                         statusCode == HttpStatus.SC_FORBIDDEN ) {
@@ -139,14 +139,10 @@ public class KeycloakAuthzClient {
                     LOG.warn("Retryable HttpResponseException with HTTP code:  {}", statusCode);
                     return true;
                 }
-            } else if (rootCause instanceof ConnectException || rootCause instanceof UnknownHostException) {
-                LOG.warn("Retryable connection exception", rootCause);
-                return true;
-            } else {
-                    // random unexpected Exceptions, don't retry, these should be debugged.
-                    LOG.error("Other non retryable exception", rootCause);
-                    return false;
-                }
+            }
+            LOG.warn("Retryable exception: ", e);
+            LOG.warn("Retryable exception root cause: ", rootCause);
+            return true;
         };
     }
 

--- a/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
+++ b/client/src/test/java/io/pravega/keycloak/client/KeycloakAuthzClientTest.java
@@ -110,6 +110,16 @@ public class KeycloakAuthzClientTest {
     }
 
     @Test
+    public void getRPTWithHttp401Exception() {
+        assertRetried(new HttpResponseException("", 401, "", null), 1);
+    }
+
+    @Test
+    public void getRPTWithHttp403Exception() {
+        assertRetried(new HttpResponseException("", 403, "", null), 1);
+    }
+
+    @Test
     public void getRPTWithRuntimeConnectException() {
         assertRetried(new RuntimeException(new ConnectException()), 3);
     }
@@ -121,7 +131,7 @@ public class KeycloakAuthzClientTest {
 
     @Test
     public void getRPTWithRandomRuntimeException() {
-        assertRetried(new RuntimeException("bogus"), 1);
+        assertRetried(new RuntimeException("bogus"), 3);
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ guavaVersion=28.2-jre
 junitVersion=4.13.2
 keycloakVersion=12.0.4
 mockitoVersion=3.3.3
-pravegaVersion=0.9.0
+pravegaVersion=0.10.0-2976.ea3db6f-SNAPSHOT
 slf4jVersion=1.7.30
 
 buildVersion=0.10.0-SNAPSHOT
@@ -27,15 +27,12 @@ buildVersion=0.10.0-SNAPSHOT
 # Properties for publishing to repository
 # ------------------------------------------------
 
-# Alternatives: mavenCentral, jcenter, localFileRepo, any string (in conjunction with `publishUrl...`
+# Alternatives: mavenCentral, localFileRepo, any string (in conjunction with `publishUrl...`
 publishRepo=localFileRepo
 
 # Repo credentials
 publishUsername=
 publishPassword=
-
-# Publish URL, when publishing to Artifactory (dev-time)
-publishUrl=https://oss.jfrog.org
 
 # Specified if a custom `publishRepo` is specified
 publishUrlForSnapshots=


### PR DESCRIPTION
Signed-off-by: Christophe Balczunas <christophe.balczunas@emc.com>

**Overview**

Fixed Issue https://github.com/pravega/pravega-keycloak/issues/47

This PR makes the keycloak client more resilient to unknown exceptions and runtime exceptions caused by network and other temporary instabilities in the environment.

It continues to identify a small set of specific 40x errors which should not be retried and lets everything else be retried including http 50x http responses and any other RuntimeExceptions or exceptions wrapped in RuntimeExceptions.

**Testing**

Relying on unit tests to mock most of this; however I did try the following in a real end 2end system with Keycloak:

- changed the client secret of the client used by the application that uses this library to force a 401 error and verified this was not retried:

```
18:12:18.141 [grpc-nio-worker-ELG-1-1] ERROR io.pravega.keycloak.client.KeycloakAuthzClient - Non retryable HttpResponseException with HTTP code: 401
18:12:18.144 [grpc-nio-worker-ELG-1-1] ERROR io.pravega.keycloak.client.KeycloakAuthzClient - Failed to obtain access token from Keycloak
io.pravega.keycloak.org.keycloak.authorization.client.util.HttpResponseException: Unexpected response from server: 401 / Unauthorized
at io.pravega.keycloak.org.keycloak.authorization.client.util.HttpMethod.execute(HttpMethod.java:95)
at io.pravega.keycloak.org.keycloak.authorization.client.util.HttpMethodResponse$2.execute(HttpMethodResponse.java:50)
```

- introduced a network problem that forced this library to run into 503 errors coming from the Keycloak endpoint.  Removed the network problem and observed the application was able to resume the connection and complete.


```
:22:38.584 [grpc-nio-worker-ELG-1-1] DEBUG io.grpc.netty.NettyClientHandler - [id: 0x6187ea66, L:/172.29.109.2:51880 - R:pravega-controller.abysscb42.nautilus-lab-ns.com/10.243.53.45:443] OUTBOUND SETTINGS: ack=true
18:22:38.626 [grpc-nio-worker-ELG-1-1] WARN io.pravega.keycloak.client.KeycloakAuthzClient - Retryable HttpResponseException with HTTP code:  503
18:22:38.731 [grpc-nio-worker-ELG-1-1] DEBUG io.pravega.common.util.Retry - Retrying command io.pravega.keycloak.client.KeycloakAuthzClient$$Lambda$122/0x000000080037e440@72ead170 due to "Unexpected response from server: 503 / Service Temporarily Unavailable" Retry #1, timestamp=2021-09-15T18:22:38.731931Z
18:22:38.743 [grpc-nio-worker-ELG-1-1] WARN io.pravega.keycloak.client.KeycloakAuthzClient - Retryable HttpResponseException with HTTP code:  503
18:22:38.944 [grpc-nio-worker-ELG-1-1] DEBUG io.pravega.common.util.Retry - Retrying command io.pravega.keycloak.client.KeycloakAuthzClient$$Lambda$122/0x000000080037e440@72ead170 due to "Unexpected response from server: 503 / Service Temporarily Unavailable" Retry #2, timestamp=2021-09-15T18:22:38.944123Z
18:22:38.947 [grpc-nio-worker-ELG-1-1] WARN io.pravega.keycloak.client.KeycloakAuthzClient - Retryable HttpResponseException with HTTP code:  503
18:22:39.347 [grpc-nio-worker-ELG-1-1] DEBUG io.pravega.common.util.Retry - Retrying command io.pravega.keycloak.client.KeycloakAuthzClient$$Lambda$122/0x000000080037e440@72ead170 due to "Unexpected response from server: 503 / Service Temporarily Unavailable" Retry #3, timestamp=2021-09-15T18:22:39.347639Z
18:22:39.350 [grpc-nio-worker-ELG-1-1] WARN io.pravega.keycloak.client.KeycloakAuthzClient - Retryable HttpResponseException with HTTP code:  503
18:22:40.151 [grpc-nio-worker-ELG-1-1] DEBUG io.pravega.common.util.Retry - Retrying command io.pravega.keycloak.client.KeycloakAuthzClient$$Lambda$122/0x000000080037e440@72ead170 due to "Unexpected response from server: 503 / Service Temporarily Unavailable" Retry #4, timestamp=2021-09-15T18:22:40.151016Z
18:22:40.154 [grpc-nio-worker-ELG-1-1] WARN io.pravega.keycloak.client.KeycloakAuthzClient - Retryable HttpResponseException with HTTP code:  503
18:22:41.754 [grpc-nio-worker-ELG-1-1] DEBUG io.pravega.common.util.Retry - Retrying command io.pravega.keycloak.client.KeycloakAuthzClient$$Lambda$122/0x000000080037e440@72ead170 due to "Unexpected response from server: 503 / Service Temporarily Unavailable" Retry #5, timestamp=2021-09-15T18:22:41.754331Z
...
...
18:23:29.835 [grpc-nio-worker-ELG-1-1] DEBUG io.pravega.keycloak.client.KeycloakAuthzClient - Obtained access token from Keycloak
18:23:29.844 [grpc-nio-worker-ELG-1-1] DEBUG io.pravega.keycloak.org.jboss.logging - Logging Provider: io.pravega.keycloak.org.jboss.logging.Slf4jLoggerProvider
18:23:29.886 [grpc-nio-worker-ELG-1-1] DEBUG io.pravega.keycloak.client.KeycloakAuthzClient - Obtained RPT from Keycloak
18:23:29.957 [grpc-nio-worker-ELG-1-1] DEBUG io.grpc.netty.NettyClientHandler - [id: 0x6187ea66, L:/172.29.109.2:51880 - R:pravega-controller.abysscb42.nautilus-lab-ns.com/10.243.53.45:443] INBOUND WINDOW_UPDATE: streamId=0 windowSizeIncrement=2147418112
```

