### PR TITLE
Issue-53:  Keycloak15 library update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ subprojects {
     }
 
     group "io.pravega"
-//    sourceCompatibility = '1.8'
+    sourceCompatibility = '1.8'
 
 
     // Creates a Jar with Java source files

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '5.1.0'
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
     id 'org.ajoberstar.grgit' version '3.1.1'
 }
 
@@ -43,7 +43,7 @@ subprojects {
     }
 
     group "io.pravega"
-    sourceCompatibility = '1.8'
+//    sourceCompatibility = '1.8'
 
 
     // Creates a Jar with Java source files

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@
 
 guavaVersion=28.2-jre
 junitVersion=4.13.2
-keycloakVersion=12.0.4
+keycloakVersion=15.0.2
 mockitoVersion=3.3.3
 pravegaVersion=0.10.1
 slf4jVersion=1.7.30

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,10 +14,10 @@ guavaVersion=28.2-jre
 junitVersion=4.13.2
 keycloakVersion=12.0.4
 mockitoVersion=3.3.3
-pravegaVersion=0.10.0-2976.ea3db6f-SNAPSHOT
+pravegaVersion=0.10.1
 slf4jVersion=1.7.30
 
-buildVersion=0.10.0-SNAPSHOT
+buildVersion=0.11.0-SNAPSHOT
 
 
 # The below release/publishing properties specified in this file below may be overridden by supplying project

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updated Keycloak client library to 15.0.2

When compiling, this started to give errors related to the shadow jar plugin.  Updated that version to fit this table: https://github.com/johnrengelman/shadow#current-status

(updated gradle to 6.8 also)

**Tested:**

Client applications against Keycloak 12 and Keycloak 15.