### PR TITLE
Issue 57: Modify build version and Pravega dependency version in master

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,10 +14,10 @@ guavaVersion=28.2-jre
 junitVersion=4.13.2
 keycloakVersion=15.1.1
 mockitoVersion=3.3.3
-pravegaVersion=0.10.1
+pravegaVersion=0.11.0
 slf4jVersion=1.7.30
 
-buildVersion=0.11.0-SNAPSHOT
+buildVersion=0.12.0-SNAPSHOT
 
 
 # The below release/publishing properties specified in this file below may be overridden by supplying project


### PR DESCRIPTION
**Change log description**
Chang build version in master to 0.12.0-SNAPSHOT, and use the latest Pravega version as dependency.

**Purpose of the change**
Fixes https://github.com/pravega/pravega-keycloak/issues/57.

**What the code does**
No code changes.

How to verify it
Build must pass.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>
