### PR TITLE
Issue 63: update snapshot version to 0.13.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ mockitoVersion=3.3.3
 pravegaVersion=0.12.0
 slf4jVersion=1.7.30
 
-buildVersion=0.12.0-SNAPSHOT
+buildVersion=0.13.0-SNAPSHOT
 
 
 # The below release/publishing properties specified in this file below may be overridden by supplying project


### PR DESCRIPTION
**Change log description**

Chang build version in master to 0.13.0-SNAPSHOT, and use the latest Pravega version as dependency.

**Purpose of the change**
Fixes #63.

**What the code does**
No code changes.

How to verify it
Build must pass.

Signed-off-by: Christophe Balczunas <christophe.balczunas@emc.com>