### PR TITLE
Keycloak client 23.0.4 upgrade changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
+    id 'com.github.johnrengelman.shadow' version '8.0.0'
     id 'org.ajoberstar.grgit' version '3.1.1'
 }
 
@@ -43,8 +43,8 @@ subprojects {
     }
 
     group "io.pravega"
-    sourceCompatibility = '1.8'
 
+    sourceCompatibility = 17
 
     // Creates a Jar with Java source files
     task sourceJar(type: Jar) {
@@ -53,7 +53,7 @@ subprojects {
     }
     
     task javadocJar(type: Jar) {
-        classifier = 'javadoc'
+        archiveClassifier = 'javadoc'
         from javadoc.destinationDir
     }
     
@@ -63,8 +63,8 @@ subprojects {
 
     jacocoTestReport {
         reports {
-            xml.enabled true
-            html.enabled false
+            xml.required = true
+            html.required = false
         }
     }
     check.dependsOn jacocoTestReport

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@
 
 guavaVersion=28.2-jre
 junitVersion=4.13.2
-keycloakVersion=21.1.2
+keycloakVersion=23.0.4
 mockitoVersion=3.3.3
 pravegaVersion=0.12.0
 slf4jVersion=1.7.30

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates Keycloak version to `23.0.4`

To make successful Gradle build,
- Updated `Gradle` to `8.6`
- Updated `com.github.johnrengelman.shadow` to `8.0.0`

```
sles15sp4:~/pravega-keycloak/pravega-keycloak # ./gradlew build
Downloading https://services.gradle.org/distributions/gradle-8.6-bin.zip
..............................................................................................................................

Welcome to Gradle 8.6!

Here are the highlights of this release:
 - Configurable encryption key for configuration cache
 - Build init improvements
 - Build authoring improvements

For more details see https://docs.gradle.org/8.6/release-notes.html

Starting a Gradle Daemon, 1 stopped Daemon could not be reused, use --status for details

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.6/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1m 38s
8 actionable tasks: 2 executed, 6 up-to-date

```